### PR TITLE
Fixes issue #41 NPE

### DIFF
--- a/src/main/java/me/NoChance/PvPManager/Managers/PlayerHandler.java
+++ b/src/main/java/me/NoChance/PvPManager/Managers/PlayerHandler.java
@@ -83,14 +83,17 @@ public class PlayerHandler {
 	}
 
 	private PvPlayer add(final Player player) {
-		if (plugin.getServer().getPlayer(player.getUniqueId()) == null)
-			return null;
 		final PvPlayer pvPlayer = new PvPlayer(player, plugin);
-		players.put(player.getUniqueId(), pvPlayer);
 		pvPlayer.loadPvPState();
-		return pvPlayer;
+		return save(pvPlayer);
 	}
 
+	private PvPlayer save(final PvPlayer p) {
+		if (plugin.getServer().getPlayer(p.getUUID()) != null) {
+			players.put(p.getUUID(), p);
+                }
+		return p;
+	}
 	public final void untag(final PvPlayer p) {
 		tagTask.getTagged().remove(p);
 		p.unTag();


### PR DESCRIPTION
https://github.com/NoChanceSD/PvPManager/issues/41

There are a variety of possible fixes:

- never return null (if possible)
- check for null

This fix employs the former: Avoid returning null.